### PR TITLE
Improve Morphic Accessibility: Add Focus Management and Tab Navigation

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -3326,6 +3326,10 @@ Morph.prototype.init = function () {
     this.customContextMenu = null;
     this.lastTime = Date.now();
     this.onNextStep = null; // optional function to be run once
+    this.isFocusable = false;
+    this.ariaLabel = null; // optional accessibility label
+    this.ariaRole = null; // optional accessibility role
+    this.screenReaderElement = null; // offscreen DOM element for screen readers
 };
 
 // Morph string representation: e.g. 'a Morph 2 [20@45 | 130@250]'
@@ -3342,6 +3346,13 @@ Morph.prototype.toString = function () {
 // Morph deleting:
 
 Morph.prototype.destroy = function () {
+    var w = this.root();
+    if (w instanceof WorldMorph && w.focused === this) {
+        w.focused = null;
+    }
+    if (this.screenReaderElement) {
+        this.removeScreenReaderElement();
+    }
     if (this.parent !== null) {
         this.fullChanged();
         this.parent.removeChild(this);
@@ -3768,12 +3779,47 @@ Morph.prototype.drawOn = function (ctx, rect) {
         }
     }
     ctx.restore();
+    // lazily create the screen reader element on first render
+    if (this.isFocusable && !this.screenReaderElement) {
+        this.createScreenReaderElement();
+    }
 };
 
 Morph.prototype.fullDrawOn = function (aContext, aRect) {
     if (!this.isVisible) {return; }
     this.drawOn(aContext, aRect);
     this.children.forEach(child => child.fullDrawOn(aContext, aRect));
+    this.drawFocusRing(aContext, aRect);
+};
+
+Morph.prototype.drawFocusRing = function (ctx, rect) {
+    var w = this.world();
+    if (!w || w.focused !== this) {return; }
+    var clipped = rect.intersect(this.bounds);
+    if (!clipped.extent().gt(ZERO)) {return; }
+    ctx.save();
+    ctx.strokeStyle = 'rgba(30, 130, 230, 0.8)';
+    ctx.lineWidth = 2.5;
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    if (ctx.roundRect) {
+        ctx.roundRect(
+            this.left() + 1,
+            this.top() + 1,
+            this.width() - 2,
+            this.height() - 2,
+            3
+        );
+    } else {
+        ctx.rect(
+            this.left() + 1,
+            this.top() + 1,
+            this.width() - 2,
+            this.height() - 2
+        );
+    }
+    ctx.stroke();
+    ctx.restore();
 };
 
 Morph.prototype.hide = function () {
@@ -4799,6 +4845,148 @@ Morph.prototype.previousTab = function (editField) {
 };
 
 */
+
+// Morph focus tabbing:
+
+Morph.prototype.allFocusableFields = function () {
+    return this.allChildren().filter(each =>
+        each.isFocusable &&
+            each.isVisible &&
+            !(each instanceof MenuItemMorph)
+    );
+};
+
+Morph.prototype.nextFocusable = function (current) {
+    var fields = this.allFocusableFields(),
+        idx = fields.indexOf(current);
+    if (idx !== -1) {
+        if (fields.length > idx + 1) {
+            return fields[idx + 1];
+        }
+    }
+    return fields[0];
+};
+
+Morph.prototype.previousFocusable = function (current) {
+    var fields = this.allFocusableFields(),
+        idx = fields.indexOf(current);
+    if (idx !== -1) {
+        if (idx > 0) {
+            return fields[idx - 1];
+        }
+        return fields[fields.length - 1];
+    }
+    return fields[0];
+};
+
+// Morph screen reader support:
+
+Morph.prototype.createScreenReaderElement = function () {
+    // create an offscreen DOM element that mirrors this morph
+    // for screen reader accessibility. The element is positioned
+    // offscreen but remains in the DOM so screen readers can find it.
+    var world = this.world(),
+        container, el;
+    if (!world || this.screenReaderElement) {return; }
+    container = world.screenReaderContainer;
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'morphic-screen-reader';
+        container.setAttribute('aria-live', 'polite');
+        container.style.position = 'absolute';
+        container.style.width = '1px';
+        container.style.height = '1px';
+        container.style.overflow = 'hidden';
+        container.style.clip = 'rect(0, 0, 0, 0)';
+        container.style.whiteSpace = 'nowrap';
+        container.style.border = '0';
+        container.style.padding = '0';
+        container.style.margin = '-1px';
+        document.body.appendChild(container);
+        world.screenReaderContainer = container;
+    }
+    el = document.createElement('button');
+    el.setAttribute('role', this.ariaRole || 'button');
+    el.setAttribute('aria-label', this.ariaLabel || this.labelString || '');
+    el.setAttribute('tabindex', '-1'); // managed by morphic, not browser
+    el.style.position = 'absolute';
+    el.style.width = '1px';
+    el.style.height = '1px';
+    el.style.overflow = 'hidden';
+    el.style.clip = 'rect(0, 0, 0, 0)';
+    el.style.whiteSpace = 'nowrap';
+    el.style.border = '0';
+    el.style.padding = '0';
+    el.style.margin = '-1px';
+    el.morphRef = this;
+
+    // when the screen reader element receives focus, focus the morph
+    el.addEventListener('focus', () => {
+        var w = this.world();
+        if (w) {
+            w.setFocus(this);
+        }
+    });
+
+    // when the screen reader element is activated, trigger the morph
+    el.addEventListener('click', (event) => {
+        event.preventDefault();
+        if (this.mouseClickLeft) {
+            this.mouseClickLeft(this.center());
+        }
+    });
+    el.addEventListener('keydown', (event) => {
+        if (event.keyCode === 13 || event.keyCode === 32) {
+            event.preventDefault();
+            if (this.mouseClickLeft) {
+                this.mouseClickLeft(this.center());
+            }
+        }
+    });
+
+    container.appendChild(el);
+    this.screenReaderElement = el;
+};
+
+Morph.prototype.updateScreenReaderElement = function () {
+    if (!this.screenReaderElement) {return; }
+    var world = this.world(),
+        el = this.screenReaderElement;
+    el.setAttribute('aria-label', this.ariaLabel || this.labelString || '');
+    el.setAttribute('role', this.ariaRole || 'button');
+    if (world && world.focused === this) {
+        el.setAttribute('aria-current', 'true');
+    } else {
+        el.removeAttribute('aria-current');
+    }
+    // update checked state for toggles
+    if (this.state !== undefined && (this.ariaRole === 'checkbox' ||
+            this.ariaRole === 'radio' ||
+            this.ariaRole === 'toggle button')) {
+        el.setAttribute('aria-checked', this.state ? 'true' : 'false');
+    }
+};
+
+Morph.prototype.removeScreenReaderElement = function () {
+    if (this.screenReaderElement) {
+        if (this.screenReaderElement.parentNode) {
+            this.screenReaderElement.parentNode.removeChild(
+                this.screenReaderElement
+            );
+        }
+        this.screenReaderElement = null;
+    }
+};
+
+Morph.prototype.ensureScreenReaderElement = function () {
+    // lazily create or update the screen reader element
+    if (!this.isFocusable) {return; }
+    if (!this.screenReaderElement) {
+        this.createScreenReaderElement();
+    } else {
+        this.updateScreenReaderElement();
+    }
+};
 
 // Morph events:
 
@@ -9871,6 +10059,9 @@ TriggerMorph.prototype.init = function (
     TriggerMorph.uber.init.call(this);
 
     // override inherited properites:
+    this.isFocusable = true;
+    this.ariaRole = 'button';
+    this.ariaLabel = labelString || null;
     this.color = WHITE;
     this.createLabel();
 };
@@ -10087,6 +10278,7 @@ function MenuItemMorph(
         italic,
         doubleClickAction
     );
+    this.isFocusable = false; // menus have their own keyboard nav
 }
 
 MenuItemMorph.prototype.createLabel = function () {
@@ -10352,6 +10544,7 @@ FrameMorph.prototype.fullDrawOn = function (ctx, aRect) {
     if (shadow) {
         shadow.drawOn(ctx, aRect);
     }
+    this.drawFocusRing(ctx, aRect);
 };
 
 // FrameMorph navigation:
@@ -11470,6 +11663,14 @@ HandMorph.prototype.processMouseDown = function (event) {
                 this.world.stopEditing();
             }
         }
+        // set focus on clicked morph if focusable
+        var focusTarget = morph;
+        while (focusTarget && !focusTarget.isFocusable) {
+            focusTarget = focusTarget.parent;
+        }
+        this.world.setFocus(
+            focusTarget && focusTarget.isFocusable ? focusTarget : null
+        );
         if (!morph.mouseMove) {
             this.morphToGrab = morph.rootForGrab();
             this.grabPosition = this.bounds.origin.copy();
@@ -12074,6 +12275,8 @@ WorldMorph.prototype.init = function (aCanvas, fillPage) {
     this.hand = new HandMorph(this);
     this.keyboardHandler = null;
     this.keyboardFocus = null;
+    this.focused = null;
+    this.screenReaderContainer = null; // offscreen container for a11y DOM
     this.cursor = null;
     this.lastEditedText = null;
     this.activeMenu = null;
@@ -12305,8 +12508,19 @@ WorldMorph.prototype.initKeyboardHandler = function () {
             // received by all browsers
             if (event.keyCode === 9) {
                 if (kbd.world.keyboardFocus &&
-                        kbd.world.keyboardFocus.processKeyPress) {
-                    kbd.world.keyboardFocus.processKeyPress(event);
+                        (kbd.world.keyboardFocus instanceof CursorMorph ||
+                        kbd.world.keyboardFocus.reactToKeyEvent)) {
+                    // text editing or script navigation handles Tab
+                    if (kbd.world.keyboardFocus.processKeyPress) {
+                        kbd.world.keyboardFocus.processKeyPress(event);
+                    }
+                } else {
+                    // focus navigation
+                    if (event.shiftKey) {
+                        kbd.world.focusPrevious();
+                    } else {
+                        kbd.world.focusNext();
+                    }
                 }
                 event.preventDefault();
             }
@@ -12554,6 +12768,55 @@ WorldMorph.prototype.previousTab = function (editField) {
         prev.selectAll();
         prev.edit();
     }
+};
+
+// WorldMorph focus management:
+
+WorldMorph.prototype.setFocus = function (aMorph) {
+    if (this.focused === aMorph) {return; }
+    if (this.focused) {
+        this.focused.rerender();
+        if (this.focused.reactToLoseFocus) {
+            this.focused.reactToLoseFocus();
+        }
+        this.focused.updateScreenReaderElement();
+    }
+    this.focused = aMorph;
+    if (aMorph) {
+        aMorph.rerender();
+        if (aMorph.scrollIntoView) {
+            aMorph.scrollIntoView();
+        }
+        if (aMorph.reactToGainFocus) {
+            aMorph.reactToGainFocus();
+        }
+        aMorph.ensureScreenReaderElement();
+        if (aMorph.screenReaderElement) {
+            aMorph.screenReaderElement.focus();
+        }
+    }
+};
+
+WorldMorph.prototype.focusNext = function () {
+    var next;
+    if (this.focused) {
+        next = this.nextFocusable(this.focused);
+    } else {
+        var fields = this.allFocusableFields();
+        next = fields.length > 0 ? fields[0] : null;
+    }
+    this.setFocus(next);
+};
+
+WorldMorph.prototype.focusPrevious = function () {
+    var prev;
+    if (this.focused) {
+        prev = this.previousFocusable(this.focused);
+    } else {
+        var fields = this.allFocusableFields();
+        prev = fields.length > 0 ? fields[fields.length - 1] : null;
+    }
+    this.setFocus(prev);
 };
 
 // WorldMorph menu:
@@ -12975,5 +13238,11 @@ WorldMorph.prototype.toggleHolesDisplay = function () {
 
 WorldMorph.prototype.destroy = function () {
     window.removeEventListener("onbeforeunload", this.onbeforeunloadListener);
+    if (this.screenReaderContainer &&
+            this.screenReaderContainer.parentNode) {
+        this.screenReaderContainer.parentNode.removeChild(
+            this.screenReaderContainer
+        );
+    }
     WorldMorph.uber.destroy.call(this);
 };

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -173,6 +173,9 @@ PushButtonMorph.prototype.init = function (
     TriggerMorph.uber.init.call(this);
 
     // override inherited properites:
+    this.isFocusable = true;
+    this.ariaRole = 'button';
+    this.ariaLabel = labelString || null;
     this.color = PushButtonMorph.prototype.color;
     this.createLabel();
     this.fixLayout();
@@ -574,6 +577,9 @@ ToggleButtonMorph.prototype.init = function (
         environment,
         hint
     );
+
+    // override for accessibility
+    this.ariaRole = 'toggle button';
 
     // override default colors if others are specified
     if (colors) {
@@ -1209,6 +1215,10 @@ ToggleMorph.prototype.init = function (
         environment,
         hint
     );
+
+    // override for accessibility
+    this.ariaRole = style === 'checkbox' ? 'checkbox' : 'radio';
+    this.ariaLabel = labelString || null;
     this.fixLayout();
     this.refresh();
 };
@@ -2648,10 +2658,17 @@ DialogBoxMorph.prototype.popUp = function (world, noFocus) {
         if (!noFocus) {world.keyboardFocus = this; }
         this.setCenter(world.center());
         this.edit();
+        // auto-focus the first focusable child for accessibility
+        var focusable = this.allFocusableFields();
+        world.setFocus(focusable.length > 0 ? focusable[0] : null);
     }
 };
 
 DialogBoxMorph.prototype.destroy = function () {
+    var world = this.world();
+    if (world) {
+        world.setFocus(null);
+    }
     DialogBoxMorph.uber.destroy.call(this);
     if (this.key) {
         delete this.instances[this.key];
@@ -2885,10 +2902,33 @@ DialogBoxMorph.prototype.fixLayout = function () {
 DialogBoxMorph.prototype.processKeyPress = nop;
 
 DialogBoxMorph.prototype.processKeyDown = function (event) {
+    var world = this.world();
     // this.inspectKeyEvent(event);
     switch (event.keyCode) {
-    case 13:
-        this.ok();
+    case 9: // Tab - navigate focusable items within the dialog
+        var next;
+        if (event.shiftKey) {
+            next = this.previousFocusable(world.focused);
+        } else {
+            next = this.nextFocusable(world.focused);
+        }
+        if (next) {
+            world.setFocus(next);
+        }
+        event.preventDefault();
+        break;
+    case 13: // Enter
+        if (world.focused && world.focused instanceof TriggerMorph) {
+            world.focused.mouseClickLeft(world.focused.center());
+        } else {
+            this.ok();
+        }
+        break;
+    case 32: // Space - activate focused morph
+        if (world.focused && world.focused instanceof TriggerMorph) {
+            world.focused.mouseClickLeft(world.focused.center());
+            event.preventDefault();
+        }
         break;
     case 27:
         this.cancel();
@@ -3231,6 +3271,9 @@ InputFieldMorph.prototype.init = function (
     this.oldContentsExtent = contents.extent();
 
     InputFieldMorph.uber.init.call(this);
+    this.isFocusable = true;
+    this.ariaRole = 'textbox';
+    this.ariaLabel = text || null;
     this.color = WHITE;
     this.add(contents);
     this.add(arrow);


### PR DESCRIPTION
## Add Focus Management and ARIA Accessibility to Morphic

This PR implements keyboard focus management and screen reader accessibility for Morphic widgets, allowing users to navigate interactive elements via Tab/Shift+Tab and exposing them to assistive technologies through an ARIA-enabled shadow DOM layer.

## Changes

### Focus Management (`morphic.js`)
- Added `isFocusable`, `ariaLabel`, `ariaRole`, and `screenReaderElement` properties to `Morph`
- Added `focused` and `screenReaderContainer` tracking to `WorldMorph`
- Implemented `WorldMorph.setFocus()`, `focusNext()`, and `focusPrevious()` for Tab navigation
- Added `allFocusableFields()`, `nextFocusable()`, and `previousFocusable()` helpers
- Draws a visible blue focus ring around the currently focused morph via `drawFocusRing()`
- Tab key routing: defers to existing `CursorMorph` (text editing) and `ScriptFocusMorph` (script navigation) handlers; otherwise triggers focus navigation
- Click-to-focus: `HandMorph.processMouseDown` walks up the morph tree to find and focus the nearest focusable ancestor
- Focus is cleared and screen reader elements are cleaned up on morph destruction

### Screen Reader Support (`morphic.js`)
- `createScreenReaderElement()` creates an offscreen `<button>` in a shared `aria-live` container appended to `document.body`
- Screen reader elements mirror ARIA role, label, and checked state; lazily created on first render
- Focusing or activating a screen reader element propagates back to the corresponding morph

### Widget Updates (`widgets.js`)
- `PushButtonMorph`, `ToggleButtonMorph`, `ToggleMorph`, and `InputFieldMorph` marked with appropriate `isFocusable`, `ariaRole`, and `ariaLabel` values
- `TriggerMorph` marked focusable with `ariaRole = 'button'`; `MenuItemMorph` explicitly excluded (menus have their own keyboard nav)
- `DialogBoxMorph.popUp` auto-focuses the first focusable child on open
- `DialogBoxMorph.processKeyDown` handles Tab (focus within dialog), Enter/Space (activate focused button), and Escape (cancel)
- `DialogBoxMorph.destroy` clears world focus on close

### Preserved Behavior
- Tab within active text editing (`CursorMorph`) continues to move between editable fields
- Tab in script navigation mode (`ScriptFocusMorph`) continues to move between scripts
- Enter/Space at the world level still fire Snap! script key events

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/dttjqtjGrNP6/implementations/Hh99kwPqzmWD) | [Guided Review](https://www.superconductor.com/tickets/dttjqtjGrNP6/implementations/Hh99kwPqzmWD?tab=guided_review)

<!-- created-by-superconductor -->